### PR TITLE
Fixed problem with links not working in ul on the tabs plugin

### DIFF
--- a/src/js/responsive.tabs.js
+++ b/src/js/responsive.tabs.js
@@ -127,7 +127,7 @@
         $("[data-tabs]").tabs();
     });
 
-    $(document).on(eclick, "[data-tabs] ul > li > a", function (event) {
+    $(document).on(eclick, "[data-tabs] > ul > li > a", function (event) {
 
         event.preventDefault();
 

--- a/tests/tabs/all.html
+++ b/tests/tabs/all.html
@@ -31,6 +31,9 @@
                     </ul>
                     <section class="tab-pane-active">
                         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                        <ul>
+                            <li><a href="#">Test Link</a> inside an unordered list</li>
+                        </ul>
                     </section>
                     <section>
                         Exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
The jQuery selector needs to select only direct child `ul` elements of the data-tabs element or all hyperlinks inside of unordered lists will be disabled.
