### PR TITLE
[gh-pages] It's now just "Bootstrap" instead of "Twitter Bootstrap".

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
                 Excerpts of this code are based on the incredibly hard work by the good people responsible for
                 <a href="http://necolas.github.io/normalize.css/" rel="external nofollow">Normalize.css</a>,
                 <a href="http://html5boilerplate.com/" rel="external nofollow">HTML5 Boilerplate</a>, and
-                <a href="http://getbootstrap.com/" rel="external nofollow">Twitter Bootstrap</a>.
+                <a href="http://getbootstrap.com/" rel="external nofollow">Bootstrap</a>.
             </p>
             <p>
                 Licensed under the <a href="http://opensource.org/licenses/MIT" rel="external nofollow">MIT License</a>.


### PR DESCRIPTION
Per http://getbootstrap.com/about/#brand
