### PR TITLE
Removed chrome=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 #Responsive
 ##A super lightweight HTML, Sass, CSS, and JavaScript framework for building responsive websites
+
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/ResponsiveBP/Responsive?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ###Responsive is the developers framework.

--- a/build/template.html
+++ b/build/template.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Your site description." />
     <title>Your page title</title>


### PR DESCRIPTION
Source: http://stackoverflow.com/questions/14637943/what-is-x-ua-compatible-when-it-references-ie-edge-chrome-1

The chrome=1 value of the X-UA-Compatible meta tag is invalid since Chrome Frame is discontinued (http://blog.chromium.org/2013/06/retiring-chrome-frame.html).