### PR TITLE
Fixed the width of the block-row grid 

### DIFF
--- a/src/sass/utilities/mixins/_grid.scss
+++ b/src/sass/utilities/mixins/_grid.scss
@@ -60,7 +60,7 @@
         .block-row-#{$breakpoint}-#{$i} {
 
             > * {
-                width: $column-width;
+                width: calc(#{$column-width} - #{$grid-column-gutter});
             }
 
             > :nth-of-type(n+1) {


### PR DESCRIPTION
It was popping down the last element due to how it was rendering width with the borders.
