### PR TITLE
Relax npm package jquery dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
         "gulp-zip": "^3.0.2"
     },
     "dependencies": {
-         "jquery": "2.1.4"
+        "jquery": ">=2.1.4"
     }
 }


### PR DESCRIPTION
Allow newer versions of jquery to be used (#105)